### PR TITLE
fix: support new shatel mobile phone number prefixes

### DIFF
--- a/persian_tools/phone_number/operators.py
+++ b/persian_tools/phone_number/operators.py
@@ -232,6 +232,37 @@ data = {
         'type': ['credit'],
         'operator': OPERATORS['ShatelMobile'],
     },
+    '99818': {
+        'province': [],
+        'base': 'کشوری',
+        'type': ['credit'],
+        'operator': OPERATORS['ShatelMobile'],
+    },
+    '99819': {
+        'province': [],
+        'base': 'کشوری',
+        'type': ['credit'],
+        'operator': OPERATORS['ShatelMobile'],
+    },
+    '99820': {
+        'province': [],
+        'base': 'کشوری',
+        'type': ['credit'],
+        'operator': OPERATORS['ShatelMobile'],
+    },
+    '99821': {
+        'province': [],
+        'base': 'کشوری',
+        'type': ['credit'],
+        'operator': OPERATORS['ShatelMobile'],
+    },
+    '99822': {
+        'province': [],
+        'base': 'کشوری',
+        'type': ['credit'],
+        'operator': OPERATORS['ShatelMobile'],
+    },
+
 
     # TeleKish
     '934': {


### PR DESCRIPTION
This new phone numbers are provided by ShatelMobile. 

refrence:
https://shatelmobile.ir/2023/12/renj22/#:~:text=%D8%B4%D8%A7%D8%AA%D9%84%E2%80%8C%20%D9%85%D9%88%D8%A8%D8%A7%DB%8C%D9%84%20%D8%B1%D9%86%D8%AC%20%D8%AC%D8%AF%DB%8C%D8%AF%20%D8%B4%D9%85%D8%A7%D8%B1%D9%87,%D8%A8%D8%A7%D8%B2%D8%A7%D8%B1%20%D8%A7%D8%B1%D8%AA%D8%A8%D8%A7%D8%B7%D8%A7%D8%AA%20%DA%A9%D8%B4%D9%88%D8%B1%20%D8%B9%D8%B1%D8%B6%D9%87%20%DA%A9%D8%B1%D8%AF.

Without this new ones, the code would raise validation error on some valid phone numbers.